### PR TITLE
fix: 英語版でカードサイズをはみ出してしまう問題を修正

### DIFF
--- a/landingpage/src/components/FeaturesSection.tsx
+++ b/landingpage/src/components/FeaturesSection.tsx
@@ -103,10 +103,10 @@ export default function FeaturesSection() {
                 ) : (
                   <>
                     <div className="text-4xl md:text-5xl mb-4">{feature.icon}</div>
-                    <h3 className="text-xl md:text-2xl font-bold mb-3">
+                    <h3 className="text-xl md:text-2xl font-bold mb-3 line-clamp-2">
                       {t(`features.${feature.id}.title`)}
                     </h3>
-                    <p className="text-gray-600 dark:text-gray-300 mb-4 flex-grow">
+                    <p className="text-gray-600 dark:text-gray-300 mb-4 flex-grow line-clamp-3">
                       {t(`features.${feature.id}.description`)}
                     </p>
 
@@ -114,7 +114,7 @@ export default function FeaturesSection() {
                     <div
                       className={`overflow-hidden transition-all duration-300 ${hoveredFeature === feature.id ? 'max-h-32 opacity-100' : 'max-h-0 opacity-0'}`}
                     >
-                      <p className="text-sm text-gray-500 dark:text-gray-400">
+                      <p className="text-sm text-gray-500 dark:text-gray-400 line-clamp-4">
                         {t(`features.${feature.id}.details`)}
                       </p>
                     </div>

--- a/landingpage/src/components/PricingSection.tsx
+++ b/landingpage/src/components/PricingSection.tsx
@@ -92,8 +92,8 @@ export default function PricingSection() {
                 </div>
               )}
 
-              <h3 className="text-2xl font-bold mb-2">{t(`pricing.plans.${plan.id}.name`)}</h3>
-              <p className="text-gray-600 dark:text-gray-400 mb-4">
+              <h3 className="text-2xl font-bold mb-2 line-clamp-1">{t(`pricing.plans.${plan.id}.name`)}</h3>
+              <p className="text-gray-600 dark:text-gray-400 mb-4 line-clamp-2">
                 {t(`pricing.plans.${plan.id}.description`)}
               </p>
 
@@ -108,7 +108,7 @@ export default function PricingSection() {
                 {plan.features.map((feature, featureIndex) => (
                   <li key={featureIndex} className="flex items-start">
                     <Check className="w-5 h-5 text-[#4ECDC4] mr-2 flex-shrink-0 mt-0.5" />
-                    <span className="text-sm">
+                    <span className="text-sm line-clamp-2">
                       {t(`pricing.plans.${plan.id}.features.${featureIndex}`)}
                     </span>
                   </li>


### PR DESCRIPTION
Fixes #9

## 変更内容

英語版でカードサイズをはみ出してしまう問題を修正しました。

Tailwind CSSの`line-clamp`ユーティリティクラスを使用して、テキストが指定行数を超えた場合に省略されるようにしました。

### FeaturesSection.tsx:
- カードタイトル: 最大2行に制限 (`line-clamp-2`)
- カード説明文: 最大3行に制限 (`line-clamp-3`)
- ホバー時の詳細: 最大4行に制限 (`line-clamp-4`)

### PricingSection.tsx:
- プラン名: 最大1行に制限 (`line-clamp-1`)
- プラン説明: 最大2行に制限 (`line-clamp-2`)
- 機能リスト: 各項目を最大2行に制限 (`line-clamp-2`)

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Improved text layout in feature and pricing cards by limiting the number of visible lines and adding ellipsis for overflow, ensuring a more consistent and compact appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->