### PR TITLE
feat: プライバシーポリシー、利用規約、特定商取引法ページを追加

### DIFF
--- a/landingpage/src/app/legal/page.tsx
+++ b/landingpage/src/app/legal/page.tsx
@@ -1,0 +1,181 @@
+'use client';
+
+import Link from 'next/link';
+import { useTranslationContext } from '@/context/TranslationContext';
+import GradientText from '@/components/GradientText';
+
+export default function LegalPage() {
+  const { t } = useTranslationContext();
+
+  return (
+    <div className="min-h-screen bg-gradient-to-b from-white to-gray-50 dark:from-gray-900 dark:to-black">
+      {/* Hero Section */}
+      <div className="relative overflow-hidden">
+        <div className="absolute inset-0">
+          <div className="absolute top-0 right-0 w-96 h-96 bg-gradient-to-br from-[#FF6B35]/20 to-transparent rounded-full blur-3xl" />
+          <div className="absolute bottom-0 left-0 w-96 h-96 bg-gradient-to-tr from-[#4ECDC4]/20 to-transparent rounded-full blur-3xl" />
+        </div>
+
+        <div className="relative max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-24">
+          <h1 className="text-4xl md:text-5xl font-bold text-center mb-8">
+            <GradientText>{t('legal.title')}</GradientText>
+          </h1>
+          <p className="text-lg text-gray-600 dark:text-gray-400 text-center mb-4">
+            {t('legal.last_updated')}: 2025年6月6日
+          </p>
+        </div>
+      </div>
+
+      {/* Content */}
+      <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 pb-24">
+        <div className="prose prose-lg dark:prose-invert max-w-none">
+          {/* 販売業者 */}
+          <section className="mb-12">
+            <h2 className="text-2xl font-bold mb-4 gradient-text">{t('legal.sections.seller.title')}</h2>
+            <div className="bg-gray-100 dark:bg-gray-800 p-6 rounded-xl space-y-3">
+              <div>
+                <span className="font-semibold">{t('legal.sections.seller.name_label')}:</span>
+                <span className="ml-2 text-gray-700 dark:text-gray-300">DogeDigger運営事務局</span>
+              </div>
+              <div>
+                <span className="font-semibold">{t('legal.sections.seller.representative_label')}:</span>
+                <span className="ml-2 text-gray-700 dark:text-gray-300">代表者名</span>
+              </div>
+              <div>
+                <span className="font-semibold">{t('legal.sections.seller.address_label')}:</span>
+                <span className="ml-2 text-gray-700 dark:text-gray-300">〒150-0000 東京都渋谷区</span>
+              </div>
+            </div>
+          </section>
+
+          {/* 連絡先 */}
+          <section className="mb-12">
+            <h2 className="text-2xl font-bold mb-4 gradient-text">{t('legal.sections.contact.title')}</h2>
+            <div className="bg-gray-100 dark:bg-gray-800 p-6 rounded-xl space-y-3">
+              <div>
+                <span className="font-semibold">{t('legal.sections.contact.email_label')}:</span>
+                <span className="ml-2 text-gray-700 dark:text-gray-300">support@dogedigger.app</span>
+              </div>
+              <div>
+                <span className="font-semibold">{t('legal.sections.contact.hours_label')}:</span>
+                <span className="ml-2 text-gray-700 dark:text-gray-300">平日 10:00-18:00（土日祝日を除く）</span>
+              </div>
+              <p className="text-sm text-gray-600 dark:text-gray-400 mt-2">
+                {t('legal.sections.contact.note')}
+              </p>
+            </div>
+          </section>
+
+          {/* 販売価格 */}
+          <section className="mb-12">
+            <h2 className="text-2xl font-bold mb-4 gradient-text">{t('legal.sections.pricing.title')}</h2>
+            <p className="text-gray-700 dark:text-gray-300 mb-4">
+              {t('legal.sections.pricing.description')}
+            </p>
+            <ul className="list-disc pl-6 space-y-2 text-gray-700 dark:text-gray-300">
+              <li>{t('legal.sections.pricing.display_price')}</li>
+              <li>{t('legal.sections.pricing.tax_included')}</li>
+              <li>{t('legal.sections.pricing.gas_fees')}</li>
+            </ul>
+          </section>
+
+          {/* 支払方法 */}
+          <section className="mb-12">
+            <h2 className="text-2xl font-bold mb-4 gradient-text">{t('legal.sections.payment.title')}</h2>
+            <ul className="list-disc pl-6 space-y-2 text-gray-700 dark:text-gray-300">
+              <li>{t('legal.sections.payment.credit_card')}</li>
+              <li>{t('legal.sections.payment.crypto')}</li>
+            </ul>
+            <p className="text-sm text-gray-600 dark:text-gray-400 mt-4">
+              {t('legal.sections.payment.note')}
+            </p>
+          </section>
+
+          {/* 支払期限 */}
+          <section className="mb-12">
+            <h2 className="text-2xl font-bold mb-4 gradient-text">{t('legal.sections.payment_timing.title')}</h2>
+            <p className="text-gray-700 dark:text-gray-300">
+              {t('legal.sections.payment_timing.description')}
+            </p>
+          </section>
+
+          {/* 商品の引渡し時期 */}
+          <section className="mb-12">
+            <h2 className="text-2xl font-bold mb-4 gradient-text">{t('legal.sections.delivery.title')}</h2>
+            <p className="text-gray-700 dark:text-gray-300 mb-4">
+              {t('legal.sections.delivery.digital_content')}
+            </p>
+            <p className="text-gray-700 dark:text-gray-300">
+              {t('legal.sections.delivery.nft')}
+            </p>
+          </section>
+
+          {/* 返品・交換について */}
+          <section className="mb-12">
+            <h2 className="text-2xl font-bold mb-4 gradient-text">{t('legal.sections.returns.title')}</h2>
+            <p className="text-gray-700 dark:text-gray-300 mb-4">
+              {t('legal.sections.returns.digital_nature')}
+            </p>
+            <p className="text-gray-700 dark:text-gray-300">
+              {t('legal.sections.returns.defect_policy')}
+            </p>
+          </section>
+
+          {/* キャンセルについて */}
+          <section className="mb-12">
+            <h2 className="text-2xl font-bold mb-4 gradient-text">{t('legal.sections.cancellation.title')}</h2>
+            <p className="text-gray-700 dark:text-gray-300">
+              {t('legal.sections.cancellation.policy')}
+            </p>
+          </section>
+
+          {/* 動作環境 */}
+          <section className="mb-12">
+            <h2 className="text-2xl font-bold mb-4 gradient-text">{t('legal.sections.requirements.title')}</h2>
+            <h3 className="text-xl font-semibold mb-3">{t('legal.sections.requirements.mobile.title')}</h3>
+            <ul className="list-disc pl-6 space-y-2 text-gray-700 dark:text-gray-300 mb-4">
+              <li>iOS 14.0以降</li>
+              <li>Android 8.0以降</li>
+            </ul>
+            
+            <h3 className="text-xl font-semibold mb-3">{t('legal.sections.requirements.ar.title')}</h3>
+            <ul className="list-disc pl-6 space-y-2 text-gray-700 dark:text-gray-300 mb-4">
+              <li>Meta Quest 3</li>
+              <li>ARKit対応デバイス（iPhone 6s以降）</li>
+              <li>ARCore対応Androidデバイス</li>
+            </ul>
+
+            <h3 className="text-xl font-semibold mb-3">{t('legal.sections.requirements.browser.title')}</h3>
+            <ul className="list-disc pl-6 space-y-2 text-gray-700 dark:text-gray-300">
+              <li>Chrome 90以降</li>
+              <li>Safari 14以降</li>
+              <li>Firefox 88以降</li>
+            </ul>
+          </section>
+
+          {/* その他の特記事項 */}
+          <section className="mb-12">
+            <h2 className="text-2xl font-bold mb-4 gradient-text">{t('legal.sections.notes.title')}</h2>
+            <ul className="list-disc pl-6 space-y-2 text-gray-700 dark:text-gray-300">
+              <li>{t('legal.sections.notes.blockchain_nature')}</li>
+              <li>{t('legal.sections.notes.crypto_wallet')}</li>
+              <li>{t('legal.sections.notes.gas_responsibility')}</li>
+              <li>{t('legal.sections.notes.age_restriction')}</li>
+            </ul>
+          </section>
+
+          {/* Back to Home */}
+          <div className="text-center mt-16">
+            <Link
+              href="/"
+              className="inline-flex items-center text-[#FF6B35] hover:text-[#FF8555] transition-colors font-medium"
+            >
+              <span className="mr-2">←</span>
+              {t('legal.back_to_home')}
+            </Link>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/landingpage/src/app/privacy/page.tsx
+++ b/landingpage/src/app/privacy/page.tsx
@@ -1,0 +1,162 @@
+'use client';
+
+import Link from 'next/link';
+import { useTranslationContext } from '@/context/TranslationContext';
+import GradientText from '@/components/GradientText';
+
+export default function PrivacyPage() {
+  const { t } = useTranslationContext();
+
+  return (
+    <div className="min-h-screen bg-gradient-to-b from-white to-gray-50 dark:from-gray-900 dark:to-black">
+      {/* Hero Section */}
+      <div className="relative overflow-hidden">
+        <div className="absolute inset-0">
+          <div className="absolute top-0 right-0 w-96 h-96 bg-gradient-to-br from-[#FF6B35]/20 to-transparent rounded-full blur-3xl" />
+          <div className="absolute bottom-0 left-0 w-96 h-96 bg-gradient-to-tr from-[#4ECDC4]/20 to-transparent rounded-full blur-3xl" />
+        </div>
+
+        <div className="relative max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-24">
+          <h1 className="text-4xl md:text-5xl font-bold text-center mb-8">
+            <GradientText>{t('privacy.title')}</GradientText>
+          </h1>
+          <p className="text-lg text-gray-600 dark:text-gray-400 text-center mb-4">
+            {t('privacy.last_updated')}: 2025年6月6日
+          </p>
+        </div>
+      </div>
+
+      {/* Content */}
+      <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 pb-24">
+        <div className="prose prose-lg dark:prose-invert max-w-none">
+          {/* Introduction */}
+          <section className="mb-12">
+            <p className="text-gray-700 dark:text-gray-300 leading-relaxed">
+              {t('privacy.introduction')}
+            </p>
+          </section>
+
+          {/* 1. Information We Collect */}
+          <section className="mb-12">
+            <h2 className="text-2xl font-bold mb-4 gradient-text">{t('privacy.sections.information_collection.title')}</h2>
+            
+            <h3 className="text-xl font-semibold mb-3">{t('privacy.sections.information_collection.personal_info.title')}</h3>
+            <ul className="list-disc pl-6 space-y-2 text-gray-700 dark:text-gray-300">
+              <li>{t('privacy.sections.information_collection.personal_info.email')}</li>
+              <li>{t('privacy.sections.information_collection.personal_info.name')}</li>
+              <li>{t('privacy.sections.information_collection.personal_info.wallet')}</li>
+            </ul>
+
+            <h3 className="text-xl font-semibold mb-3 mt-6">{t('privacy.sections.information_collection.usage_info.title')}</h3>
+            <ul className="list-disc pl-6 space-y-2 text-gray-700 dark:text-gray-300">
+              <li>{t('privacy.sections.information_collection.usage_info.location')}</li>
+              <li>{t('privacy.sections.information_collection.usage_info.device')}</li>
+              <li>{t('privacy.sections.information_collection.usage_info.interaction')}</li>
+            </ul>
+
+            <h3 className="text-xl font-semibold mb-3 mt-6">{t('privacy.sections.information_collection.generated_content.title')}</h3>
+            <ul className="list-disc pl-6 space-y-2 text-gray-700 dark:text-gray-300">
+              <li>{t('privacy.sections.information_collection.generated_content.ai_art')}</li>
+              <li>{t('privacy.sections.information_collection.generated_content.nft_data')}</li>
+            </ul>
+          </section>
+
+          {/* 2. How We Use Information */}
+          <section className="mb-12">
+            <h2 className="text-2xl font-bold mb-4 gradient-text">{t('privacy.sections.information_use.title')}</h2>
+            <ul className="list-disc pl-6 space-y-2 text-gray-700 dark:text-gray-300">
+              <li>{t('privacy.sections.information_use.service_provision')}</li>
+              <li>{t('privacy.sections.information_use.nft_management')}</li>
+              <li>{t('privacy.sections.information_use.improvement')}</li>
+              <li>{t('privacy.sections.information_use.communication')}</li>
+              <li>{t('privacy.sections.information_use.legal')}</li>
+            </ul>
+          </section>
+
+          {/* 3. Data Sharing */}
+          <section className="mb-12">
+            <h2 className="text-2xl font-bold mb-4 gradient-text">{t('privacy.sections.data_sharing.title')}</h2>
+            <p className="text-gray-700 dark:text-gray-300 mb-4">
+              {t('privacy.sections.data_sharing.introduction')}
+            </p>
+            <ul className="list-disc pl-6 space-y-2 text-gray-700 dark:text-gray-300">
+              <li>{t('privacy.sections.data_sharing.blockchain')}</li>
+              <li>{t('privacy.sections.data_sharing.service_providers')}</li>
+              <li>{t('privacy.sections.data_sharing.legal_requirements')}</li>
+            </ul>
+          </section>
+
+          {/* 4. Data Security */}
+          <section className="mb-12">
+            <h2 className="text-2xl font-bold mb-4 gradient-text">{t('privacy.sections.data_security.title')}</h2>
+            <p className="text-gray-700 dark:text-gray-300">
+              {t('privacy.sections.data_security.description')}
+            </p>
+          </section>
+
+          {/* 5. Your Rights */}
+          <section className="mb-12">
+            <h2 className="text-2xl font-bold mb-4 gradient-text">{t('privacy.sections.your_rights.title')}</h2>
+            <ul className="list-disc pl-6 space-y-2 text-gray-700 dark:text-gray-300">
+              <li>{t('privacy.sections.your_rights.access')}</li>
+              <li>{t('privacy.sections.your_rights.correction')}</li>
+              <li>{t('privacy.sections.your_rights.deletion')}</li>
+              <li>{t('privacy.sections.your_rights.portability')}</li>
+              <li>{t('privacy.sections.your_rights.objection')}</li>
+            </ul>
+          </section>
+
+          {/* 6. Cookies */}
+          <section className="mb-12">
+            <h2 className="text-2xl font-bold mb-4 gradient-text">{t('privacy.sections.cookies.title')}</h2>
+            <p className="text-gray-700 dark:text-gray-300">
+              {t('privacy.sections.cookies.description')}
+            </p>
+          </section>
+
+          {/* 7. Children's Privacy */}
+          <section className="mb-12">
+            <h2 className="text-2xl font-bold mb-4 gradient-text">{t('privacy.sections.children.title')}</h2>
+            <p className="text-gray-700 dark:text-gray-300">
+              {t('privacy.sections.children.description')}
+            </p>
+          </section>
+
+          {/* 8. Updates */}
+          <section className="mb-12">
+            <h2 className="text-2xl font-bold mb-4 gradient-text">{t('privacy.sections.updates.title')}</h2>
+            <p className="text-gray-700 dark:text-gray-300">
+              {t('privacy.sections.updates.description')}
+            </p>
+          </section>
+
+          {/* 9. Contact */}
+          <section className="mb-12">
+            <h2 className="text-2xl font-bold mb-4 gradient-text">{t('privacy.sections.contact.title')}</h2>
+            <p className="text-gray-700 dark:text-gray-300 mb-4">
+              {t('privacy.sections.contact.description')}
+            </p>
+            <div className="bg-gray-100 dark:bg-gray-800 p-6 rounded-xl">
+              <p className="font-semibold mb-2">DogeDigger Team</p>
+              <p className="text-gray-600 dark:text-gray-400">
+                Email: privacy@dogedigger.app<br />
+                Address: 東京都渋谷区
+              </p>
+            </div>
+          </section>
+
+          {/* Back to Home */}
+          <div className="text-center mt-16">
+            <Link
+              href="/"
+              className="inline-flex items-center text-[#FF6B35] hover:text-[#FF8555] transition-colors font-medium"
+            >
+              <span className="mr-2">←</span>
+              {t('privacy.back_to_home')}
+            </Link>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/landingpage/src/app/terms/page.tsx
+++ b/landingpage/src/app/terms/page.tsx
@@ -1,0 +1,211 @@
+'use client';
+
+import Link from 'next/link';
+import { useTranslationContext } from '@/context/TranslationContext';
+import GradientText from '@/components/GradientText';
+
+export default function TermsPage() {
+  const { t } = useTranslationContext();
+
+  return (
+    <div className="min-h-screen bg-gradient-to-b from-white to-gray-50 dark:from-gray-900 dark:to-black">
+      {/* Hero Section */}
+      <div className="relative overflow-hidden">
+        <div className="absolute inset-0">
+          <div className="absolute top-0 right-0 w-96 h-96 bg-gradient-to-br from-[#FF6B35]/20 to-transparent rounded-full blur-3xl" />
+          <div className="absolute bottom-0 left-0 w-96 h-96 bg-gradient-to-tr from-[#4ECDC4]/20 to-transparent rounded-full blur-3xl" />
+        </div>
+
+        <div className="relative max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-24">
+          <h1 className="text-4xl md:text-5xl font-bold text-center mb-8">
+            <GradientText>{t('terms.title')}</GradientText>
+          </h1>
+          <p className="text-lg text-gray-600 dark:text-gray-400 text-center mb-4">
+            {t('terms.last_updated')}: 2025年6月6日
+          </p>
+        </div>
+      </div>
+
+      {/* Content */}
+      <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 pb-24">
+        <div className="prose prose-lg dark:prose-invert max-w-none">
+          {/* Introduction */}
+          <section className="mb-12">
+            <p className="text-gray-700 dark:text-gray-300 leading-relaxed">
+              {t('terms.introduction')}
+            </p>
+          </section>
+
+          {/* 1. Service Overview */}
+          <section className="mb-12">
+            <h2 className="text-2xl font-bold mb-4 gradient-text">{t('terms.sections.service_overview.title')}</h2>
+            <p className="text-gray-700 dark:text-gray-300 mb-4">
+              {t('terms.sections.service_overview.description')}
+            </p>
+            <ul className="list-disc pl-6 space-y-2 text-gray-700 dark:text-gray-300">
+              <li>{t('terms.sections.service_overview.robot_dog')}</li>
+              <li>{t('terms.sections.service_overview.ar_treasure')}</li>
+              <li>{t('terms.sections.service_overview.ai_art')}</li>
+              <li>{t('terms.sections.service_overview.nft_minting')}</li>
+            </ul>
+          </section>
+
+          {/* 2. User Eligibility */}
+          <section className="mb-12">
+            <h2 className="text-2xl font-bold mb-4 gradient-text">{t('terms.sections.eligibility.title')}</h2>
+            <p className="text-gray-700 dark:text-gray-300 mb-4">
+              {t('terms.sections.eligibility.description')}
+            </p>
+            <ul className="list-disc pl-6 space-y-2 text-gray-700 dark:text-gray-300">
+              <li>{t('terms.sections.eligibility.age')}</li>
+              <li>{t('terms.sections.eligibility.legal_capacity')}</li>
+              <li>{t('terms.sections.eligibility.compliance')}</li>
+            </ul>
+          </section>
+
+          {/* 3. Account Registration */}
+          <section className="mb-12">
+            <h2 className="text-2xl font-bold mb-4 gradient-text">{t('terms.sections.account.title')}</h2>
+            <p className="text-gray-700 dark:text-gray-300 mb-4">
+              {t('terms.sections.account.description')}
+            </p>
+            <ul className="list-disc pl-6 space-y-2 text-gray-700 dark:text-gray-300">
+              <li>{t('terms.sections.account.accurate_info')}</li>
+              <li>{t('terms.sections.account.security')}</li>
+              <li>{t('terms.sections.account.responsibility')}</li>
+            </ul>
+          </section>
+
+          {/* 4. NFT and Digital Assets */}
+          <section className="mb-12">
+            <h2 className="text-2xl font-bold mb-4 gradient-text">{t('terms.sections.nft.title')}</h2>
+            <p className="text-gray-700 dark:text-gray-300 mb-4">
+              {t('terms.sections.nft.description')}
+            </p>
+            <ul className="list-disc pl-6 space-y-2 text-gray-700 dark:text-gray-300">
+              <li>{t('terms.sections.nft.ownership')}</li>
+              <li>{t('terms.sections.nft.blockchain')}</li>
+              <li>{t('terms.sections.nft.gas_fees')}</li>
+              <li>{t('terms.sections.nft.no_guarantee')}</li>
+            </ul>
+          </section>
+
+          {/* 5. Acceptable Use */}
+          <section className="mb-12">
+            <h2 className="text-2xl font-bold mb-4 gradient-text">{t('terms.sections.acceptable_use.title')}</h2>
+            <p className="text-gray-700 dark:text-gray-300 mb-4">
+              {t('terms.sections.acceptable_use.description')}
+            </p>
+            <ul className="list-disc pl-6 space-y-2 text-gray-700 dark:text-gray-300">
+              <li>{t('terms.sections.acceptable_use.lawful')}</li>
+              <li>{t('terms.sections.acceptable_use.no_harm')}</li>
+              <li>{t('terms.sections.acceptable_use.no_interference')}</li>
+              <li>{t('terms.sections.acceptable_use.no_reverse_engineering')}</li>
+            </ul>
+          </section>
+
+          {/* 6. Intellectual Property */}
+          <section className="mb-12">
+            <h2 className="text-2xl font-bold mb-4 gradient-text">{t('terms.sections.intellectual_property.title')}</h2>
+            <p className="text-gray-700 dark:text-gray-300 mb-4">
+              {t('terms.sections.intellectual_property.description')}
+            </p>
+            <h3 className="text-xl font-semibold mb-3">{t('terms.sections.intellectual_property.user_content.title')}</h3>
+            <p className="text-gray-700 dark:text-gray-300 mb-4">
+              {t('terms.sections.intellectual_property.user_content.description')}
+            </p>
+            <h3 className="text-xl font-semibold mb-3">{t('terms.sections.intellectual_property.ai_generated.title')}</h3>
+            <p className="text-gray-700 dark:text-gray-300">
+              {t('terms.sections.intellectual_property.ai_generated.description')}
+            </p>
+          </section>
+
+          {/* 7. Privacy */}
+          <section className="mb-12">
+            <h2 className="text-2xl font-bold mb-4 gradient-text">{t('terms.sections.privacy.title')}</h2>
+            <p className="text-gray-700 dark:text-gray-300">
+              {t('terms.sections.privacy.description')}
+            </p>
+          </section>
+
+          {/* 8. Disclaimers */}
+          <section className="mb-12">
+            <h2 className="text-2xl font-bold mb-4 gradient-text">{t('terms.sections.disclaimers.title')}</h2>
+            <p className="text-gray-700 dark:text-gray-300 mb-4">
+              {t('terms.sections.disclaimers.as_is')}
+            </p>
+            <p className="text-gray-700 dark:text-gray-300">
+              {t('terms.sections.disclaimers.no_warranty')}
+            </p>
+          </section>
+
+          {/* 9. Limitation of Liability */}
+          <section className="mb-12">
+            <h2 className="text-2xl font-bold mb-4 gradient-text">{t('terms.sections.liability.title')}</h2>
+            <p className="text-gray-700 dark:text-gray-300">
+              {t('terms.sections.liability.description')}
+            </p>
+          </section>
+
+          {/* 10. Indemnification */}
+          <section className="mb-12">
+            <h2 className="text-2xl font-bold mb-4 gradient-text">{t('terms.sections.indemnification.title')}</h2>
+            <p className="text-gray-700 dark:text-gray-300">
+              {t('terms.sections.indemnification.description')}
+            </p>
+          </section>
+
+          {/* 11. Termination */}
+          <section className="mb-12">
+            <h2 className="text-2xl font-bold mb-4 gradient-text">{t('terms.sections.termination.title')}</h2>
+            <p className="text-gray-700 dark:text-gray-300">
+              {t('terms.sections.termination.description')}
+            </p>
+          </section>
+
+          {/* 12. Governing Law */}
+          <section className="mb-12">
+            <h2 className="text-2xl font-bold mb-4 gradient-text">{t('terms.sections.governing_law.title')}</h2>
+            <p className="text-gray-700 dark:text-gray-300">
+              {t('terms.sections.governing_law.description')}
+            </p>
+          </section>
+
+          {/* 13. Changes to Terms */}
+          <section className="mb-12">
+            <h2 className="text-2xl font-bold mb-4 gradient-text">{t('terms.sections.changes.title')}</h2>
+            <p className="text-gray-700 dark:text-gray-300">
+              {t('terms.sections.changes.description')}
+            </p>
+          </section>
+
+          {/* 14. Contact Information */}
+          <section className="mb-12">
+            <h2 className="text-2xl font-bold mb-4 gradient-text">{t('terms.sections.contact.title')}</h2>
+            <p className="text-gray-700 dark:text-gray-300 mb-4">
+              {t('terms.sections.contact.description')}
+            </p>
+            <div className="bg-gray-100 dark:bg-gray-800 p-6 rounded-xl">
+              <p className="font-semibold mb-2">DogeDigger Team</p>
+              <p className="text-gray-600 dark:text-gray-400">
+                Email: legal@dogedigger.app<br />
+                Address: 東京都渋谷区
+              </p>
+            </div>
+          </section>
+
+          {/* Back to Home */}
+          <div className="text-center mt-16">
+            <Link
+              href="/"
+              className="inline-flex items-center text-[#FF6B35] hover:text-[#FF8555] transition-colors font-medium"
+            >
+              <span className="mr-2">←</span>
+              {t('terms.back_to_home')}
+            </Link>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/landingpage/src/components/Footer.tsx
+++ b/landingpage/src/components/Footer.tsx
@@ -16,9 +16,9 @@ export default function Footer() {
       { label: t('footer.product_links.roadmap'), href: '#roadmap' },
     ],
     legal: [
-      { label: t('footer.legal_links.terms'), href: '#terms' },
-      { label: t('footer.legal_links.privacy'), href: '#privacy' },
-      { label: t('footer.legal_links.legal'), href: '#legal' },
+      { label: t('footer.legal_links.terms'), href: '/terms' },
+      { label: t('footer.legal_links.privacy'), href: '/privacy' },
+      { label: t('footer.legal_links.legal'), href: '/legal' },
     ],
     social: [
       { label: t('footer.social_links.twitter'), href: 'https://twitter.com', icon: '𝕏' },

--- a/landingpage/src/i18n/messages/en.json
+++ b/landingpage/src/i18n/messages/en.json
@@ -181,5 +181,236 @@
     "status": "All systems operational",
     "copyright": "© 2025 DogeDigger. All rights reserved.",
     "made_with": "Made with 🐕 by the DogeDigger team"
+  },
+  "privacy": {
+    "title": "Privacy Policy",
+    "last_updated": "Last Updated",
+    "introduction": "DogeDigger ('we', 'our', or 'us') respects your privacy and is committed to protecting your personal information. This Privacy Policy explains how we collect, use, share, and protect your information.",
+    "back_to_home": "Back to Home",
+    "sections": {
+      "information_collection": {
+        "title": "1. Information We Collect",
+        "personal_info": {
+          "title": "Personal Information",
+          "email": "Email address",
+          "name": "Name (optional)",
+          "wallet": "Wallet address (for NFT usage)"
+        },
+        "usage_info": {
+          "title": "Usage Information",
+          "location": "Location data (during AR treasure hunting)",
+          "device": "Device information (model, OS, etc.)",
+          "interaction": "Service usage history"
+        },
+        "generated_content": {
+          "title": "Generated Content",
+          "ai_art": "AI-generated art metadata",
+          "nft_data": "NFT transaction information"
+        }
+      },
+      "information_use": {
+        "title": "2. How We Use Your Information",
+        "service_provision": "Providing and improving our services",
+        "nft_management": "NFT generation and management",
+        "improvement": "Enhancing user experience",
+        "communication": "Communicating with you",
+        "legal": "Complying with legal obligations"
+      },
+      "data_sharing": {
+        "title": "3. Information Sharing",
+        "introduction": "We do not sell, rent, or share your personal information with third parties except in the following cases:",
+        "blockchain": "Public information on blockchain (NFT-related)",
+        "service_providers": "Service providers necessary for our operations",
+        "legal_requirements": "When required by law"
+      },
+      "data_security": {
+        "title": "4. Data Security",
+        "description": "We implement industry-standard security measures to protect your information. We use encryption, access controls, and regular security audits to ensure the safety of your data."
+      },
+      "your_rights": {
+        "title": "5. Your Rights",
+        "access": "Right to access your personal information",
+        "correction": "Right to correct or update information",
+        "deletion": "Right to request deletion",
+        "portability": "Right to data portability",
+        "objection": "Right to object to processing"
+      },
+      "cookies": {
+        "title": "6. Cookies",
+        "description": "We use cookies to improve and personalize our services. You can control cookie usage through your browser settings."
+      },
+      "children": {
+        "title": "7. Children's Privacy",
+        "description": "Our services are intended for users aged 13 and above. We do not intentionally collect personal information from children under 13."
+      },
+      "updates": {
+        "title": "8. Policy Updates",
+        "description": "This Privacy Policy may be updated from time to time. We will notify you of significant changes through our service or email."
+      },
+      "contact": {
+        "title": "9. Contact Us",
+        "description": "If you have questions or concerns about privacy, please contact us at:"
+      }
+    }
+  },
+  "terms": {
+    "title": "Terms of Service",
+    "last_updated": "Last Updated",
+    "introduction": "These Terms of Service ('Terms') define the conditions for using services provided by DogeDigger ('we', 'our', or 'us'). Please read these Terms carefully before using our services.",
+    "back_to_home": "Back to Home",
+    "sections": {
+      "service_overview": {
+        "title": "1. Service Overview",
+        "description": "DogeDigger provides the following services:",
+        "robot_dog": "Real-world exploration using robot dogs",
+        "ar_treasure": "AR treasure hunting experiences",
+        "ai_art": "AI-generated art creation",
+        "nft_minting": "NFT minting of generated art"
+      },
+      "eligibility": {
+        "title": "2. Eligibility",
+        "description": "To use our services, you must:",
+        "age": "Be at least 13 years old",
+        "legal_capacity": "Have legal capacity to enter contracts",
+        "compliance": "Comply with these Terms"
+      },
+      "account": {
+        "title": "3. Account Registration",
+        "description": "Some services require account registration:",
+        "accurate_info": "Provide accurate information",
+        "security": "Maintain account security",
+        "responsibility": "Be responsible for account activities"
+      },
+      "nft": {
+        "title": "4. NFT and Digital Assets",
+        "description": "Important NFT information:",
+        "ownership": "NFT ownership is recorded on blockchain",
+        "blockchain": "We use Base chain",
+        "gas_fees": "Gas fees are your responsibility",
+        "no_guarantee": "No value guarantee"
+      },
+      "acceptable_use": {
+        "title": "5. Acceptable Use",
+        "description": "The following activities are prohibited:",
+        "lawful": "Illegal activities",
+        "no_harm": "Harassing others",
+        "no_interference": "Interfering with service operations",
+        "no_reverse_engineering": "Reverse engineering"
+      },
+      "intellectual_property": {
+        "title": "6. Intellectual Property",
+        "description": "Regarding intellectual property rights:",
+        "user_content": {
+          "title": "User Content",
+          "description": "You retain rights to content you create. However, you grant us necessary licenses to provide our services."
+        },
+        "ai_generated": {
+          "title": "AI-Generated Content",
+          "description": "Copyright in AI-generated art is transferred to you upon NFT minting."
+        }
+      },
+      "privacy": {
+        "title": "7. Privacy",
+        "description": "Please refer to our Privacy Policy for information on how we handle personal data."
+      },
+      "disclaimers": {
+        "title": "8. Disclaimers",
+        "as_is": "Services are provided 'as is'.",
+        "no_warranty": "We make no warranties regarding completeness, accuracy, or usefulness of our services."
+      },
+      "liability": {
+        "title": "9. Limitation of Liability",
+        "description": "To the maximum extent permitted by law, we are not liable for indirect, incidental, special, or consequential damages."
+      },
+      "indemnification": {
+        "title": "10. Indemnification",
+        "description": "You agree to indemnify and defend us from third-party claims arising from your use of our services."
+      },
+      "termination": {
+        "title": "11. Termination",
+        "description": "You may delete your account at any time. We reserve the right to suspend services for Terms violations."
+      },
+      "governing_law": {
+        "title": "12. Governing Law",
+        "description": "These Terms are governed by Japanese law, with Tokyo District Court as the exclusive jurisdiction."
+      },
+      "changes": {
+        "title": "13. Changes to Terms",
+        "description": "We may update these Terms as needed. We will notify you of significant changes."
+      },
+      "contact": {
+        "title": "14. Contact Information",
+        "description": "For questions about these Terms, please contact us at:"
+      }
+    }
+  },
+  "legal": {
+    "title": "Legal Notice",
+    "last_updated": "Last Updated",
+    "back_to_home": "Back to Home",
+    "sections": {
+      "seller": {
+        "title": "Seller Information",
+        "name_label": "Business Name",
+        "representative_label": "Representative",
+        "address_label": "Address"
+      },
+      "contact": {
+        "title": "Contact Information",
+        "email_label": "Email Address",
+        "hours_label": "Business Hours",
+        "note": "Inquiries are accepted via email."
+      },
+      "pricing": {
+        "title": "Pricing",
+        "description": "Prices for each service plan are displayed on the service page.",
+        "display_price": "Displayed prices are the payment amount",
+        "tax_included": "Prices include tax",
+        "gas_fees": "NFT minting gas fees are separate"
+      },
+      "payment": {
+        "title": "Payment Methods",
+        "credit_card": "Credit Cards (Visa, Mastercard, American Express, JCB)",
+        "crypto": "Cryptocurrency (ETH, USDC)",
+        "note": "Payments are processed through secure payment systems."
+      },
+      "payment_timing": {
+        "title": "Payment Terms",
+        "description": "Payment required before service use. Monthly plans auto-renew."
+      },
+      "delivery": {
+        "title": "Delivery Time",
+        "digital_content": "Digital content is available immediately after payment.",
+        "nft": "NFTs are sent to specified wallet addresses after generation."
+      },
+      "returns": {
+        "title": "Returns and Exchanges",
+        "digital_nature": "Due to the digital nature, returns and exchanges are generally not accepted.",
+        "defect_policy": "If there are service defects, please contact support promptly."
+      },
+      "cancellation": {
+        "title": "Cancellation Policy",
+        "policy": "Monthly plans can be cancelled 24 hours before renewal. No prorated refunds."
+      },
+      "requirements": {
+        "title": "System Requirements",
+        "mobile": {
+          "title": "Mobile App"
+        },
+        "ar": {
+          "title": "AR-Compatible Devices"
+        },
+        "browser": {
+          "title": "Recommended Browsers"
+        }
+      },
+      "notes": {
+        "title": "Additional Notes",
+        "blockchain_nature": "Blockchain transactions are irreversible",
+        "crypto_wallet": "Crypto wallet required for NFT receipt",
+        "gas_responsibility": "Gas fee fluctuation risk is customer's responsibility",
+        "age_restriction": "Not available for users under 13"
+      }
+    }
   }
 }

--- a/landingpage/src/i18n/messages/ja.json
+++ b/landingpage/src/i18n/messages/ja.json
@@ -176,5 +176,236 @@
     "status": "All systems operational",
     "copyright": "© 2025 DogeDigger. All rights reserved.",
     "made_with": "Made with 🐕 by the DogeDigger team"
+  },
+  "privacy": {
+    "title": "プライバシーポリシー",
+    "last_updated": "最終更新日",
+    "introduction": "DogeDigger（以下「当社」）は、お客様のプライバシーを尊重し、個人情報の保護に努めています。このプライバシーポリシーは、当社がどのようにお客様の情報を収集、使用、共有、保護するかについて説明します。",
+    "back_to_home": "ホームに戻る",
+    "sections": {
+      "information_collection": {
+        "title": "1. 収集する情報",
+        "personal_info": {
+          "title": "個人情報",
+          "email": "メールアドレス",
+          "name": "お名前（任意）",
+          "wallet": "ウォレットアドレス（NFT利用時）"
+        },
+        "usage_info": {
+          "title": "利用情報",
+          "location": "位置情報（AR宝探し時）",
+          "device": "デバイス情報（機種、OS等）",
+          "interaction": "サービス利用履歴"
+        },
+        "generated_content": {
+          "title": "生成コンテンツ",
+          "ai_art": "AI生成アートのメタデータ",
+          "nft_data": "NFTトランザクション情報"
+        }
+      },
+      "information_use": {
+        "title": "2. 情報の利用目的",
+        "service_provision": "サービスの提供・改善",
+        "nft_management": "NFTの生成・管理",
+        "improvement": "ユーザー体験の向上",
+        "communication": "お客様へのご連絡",
+        "legal": "法的義務の遵守"
+      },
+      "data_sharing": {
+        "title": "3. 情報の共有",
+        "introduction": "当社は、以下の場合を除き、お客様の個人情報を第三者に販売、貸与、または共有することはありません：",
+        "blockchain": "ブロックチェーン上の公開情報（NFT関連）",
+        "service_providers": "サービス提供に必要な委託先",
+        "legal_requirements": "法的要求がある場合"
+      },
+      "data_security": {
+        "title": "4. データセキュリティ",
+        "description": "当社は、お客様の情報を保護するため、業界標準のセキュリティ対策を実施しています。暗号化、アクセス制御、定期的なセキュリティ監査等により、お客様の情報の安全性を確保しています。"
+      },
+      "your_rights": {
+        "title": "5. お客様の権利",
+        "access": "個人情報へのアクセス権",
+        "correction": "情報の訂正・更新権",
+        "deletion": "情報の削除要求権",
+        "portability": "データポータビリティ権",
+        "objection": "処理に対する異議申立権"
+      },
+      "cookies": {
+        "title": "6. クッキーの使用",
+        "description": "当社は、サービスの改善とパーソナライズのためにクッキーを使用します。ブラウザの設定により、クッキーの使用を制限することができます。"
+      },
+      "children": {
+        "title": "7. お子様のプライバシー",
+        "description": "当社のサービスは13歳以上の方を対象としています。13歳未満のお子様の個人情報を意図的に収集することはありません。"
+      },
+      "updates": {
+        "title": "8. ポリシーの更新",
+        "description": "このプライバシーポリシーは必要に応じて更新されることがあります。重要な変更がある場合は、サービス内またはメールでお知らせします。"
+      },
+      "contact": {
+        "title": "9. お問い合わせ",
+        "description": "プライバシーに関するご質問やご懸念がございましたら、以下までお問い合わせください："
+      }
+    }
+  },
+  "terms": {
+    "title": "利用規約",
+    "last_updated": "最終更新日",
+    "introduction": "この利用規約（以下「本規約」）は、DogeDigger（以下「当社」）が提供するサービスの利用条件を定めるものです。本サービスをご利用いただく前に、必ず本規約をお読みください。",
+    "back_to_home": "ホームに戻る",
+    "sections": {
+      "service_overview": {
+        "title": "1. サービス概要",
+        "description": "DogeDiggerは、以下のサービスを提供します：",
+        "robot_dog": "ロボット犬を使用した現実世界の探索",
+        "ar_treasure": "AR技術による宝探し体験",
+        "ai_art": "AI生成アートの作成",
+        "nft_minting": "生成アートのNFT化"
+      },
+      "eligibility": {
+        "title": "2. 利用資格",
+        "description": "本サービスを利用するには、以下の条件を満たす必要があります：",
+        "age": "13歳以上であること",
+        "legal_capacity": "法的な契約締結能力を有すること",
+        "compliance": "本規約を遵守すること"
+      },
+      "account": {
+        "title": "3. アカウント登録",
+        "description": "一部のサービス利用にはアカウント登録が必要です：",
+        "accurate_info": "正確な情報を提供すること",
+        "security": "アカウントのセキュリティを維持すること",
+        "responsibility": "アカウントでの活動に責任を持つこと"
+      },
+      "nft": {
+        "title": "4. NFTとデジタル資産",
+        "description": "NFTに関する重要事項：",
+        "ownership": "NFT所有権はブロックチェーン上に記録されます",
+        "blockchain": "Baseチェーンを使用します",
+        "gas_fees": "ガス代はお客様負担となります",
+        "no_guarantee": "価値の保証はありません"
+      },
+      "acceptable_use": {
+        "title": "5. 利用上の注意",
+        "description": "以下の行為は禁止されています：",
+        "lawful": "違法行為",
+        "no_harm": "他者への迷惑行為",
+        "no_interference": "サービスの妨害",
+        "no_reverse_engineering": "リバースエンジニアリング"
+      },
+      "intellectual_property": {
+        "title": "6. 知的財産権",
+        "description": "サービスに関する知的財産権について：",
+        "user_content": {
+          "title": "ユーザーコンテンツ",
+          "description": "お客様が生成したコンテンツの権利はお客様に帰属します。ただし、当社はサービス提供のために必要な範囲で使用許諾を受けるものとします。"
+        },
+        "ai_generated": {
+          "title": "AI生成コンテンツ",
+          "description": "AI生成アートの著作権は、NFT化によりお客様に譲渡されます。"
+        }
+      },
+      "privacy": {
+        "title": "7. プライバシー",
+        "description": "個人情報の取り扱いについては、プライバシーポリシーをご確認ください。"
+      },
+      "disclaimers": {
+        "title": "8. 免責事項",
+        "as_is": "本サービスは「現状有姿」で提供されます。",
+        "no_warranty": "当社は、サービスの完全性、正確性、有用性等について、いかなる保証も行いません。"
+      },
+      "liability": {
+        "title": "9. 責任制限",
+        "description": "法令で認められる最大限の範囲において、当社は間接的、偶発的、特別、結果的損害について責任を負いません。"
+      },
+      "indemnification": {
+        "title": "10. 補償",
+        "description": "お客様は、本サービスの利用に起因する第三者からの請求について、当社を補償し、防御するものとします。"
+      },
+      "termination": {
+        "title": "11. 解約",
+        "description": "お客様はいつでもアカウントを削除できます。当社は、規約違反の場合、サービスを停止する権利を有します。"
+      },
+      "governing_law": {
+        "title": "12. 準拠法",
+        "description": "本規約は日本法に準拠し、東京地方裁判所を専属的合意管轄裁判所とします。"
+      },
+      "changes": {
+        "title": "13. 規約の変更",
+        "description": "当社は必要に応じて本規約を変更することがあります。重要な変更はお客様に通知します。"
+      },
+      "contact": {
+        "title": "14. お問い合わせ",
+        "description": "本規約に関するご質問は、以下までお問い合わせください："
+      }
+    }
+  },
+  "legal": {
+    "title": "特定商取引法に基づく表記",
+    "last_updated": "最終更新日",
+    "back_to_home": "ホームに戻る",
+    "sections": {
+      "seller": {
+        "title": "販売業者",
+        "name_label": "事業者名",
+        "representative_label": "代表者",
+        "address_label": "所在地"
+      },
+      "contact": {
+        "title": "連絡先",
+        "email_label": "メールアドレス",
+        "hours_label": "営業時間",
+        "note": "お問い合わせはメールにて承っております。"
+      },
+      "pricing": {
+        "title": "販売価格",
+        "description": "各サービスプランの価格は、サービスページに表示されている通りです。",
+        "display_price": "表示価格がお支払い金額となります",
+        "tax_included": "価格は税込表示です",
+        "gas_fees": "NFTミント時のガス代は別途必要です"
+      },
+      "payment": {
+        "title": "支払方法",
+        "credit_card": "クレジットカード（Visa、Mastercard、American Express、JCB）",
+        "crypto": "暗号資産（ETH、USDC）",
+        "note": "決済は安全な決済システムを通じて処理されます。"
+      },
+      "payment_timing": {
+        "title": "支払期限",
+        "description": "サービス利用開始前にお支払いください。月額プランは毎月自動更新されます。"
+      },
+      "delivery": {
+        "title": "商品の引渡し時期",
+        "digital_content": "デジタルコンテンツは決済完了後、即時利用可能となります。",
+        "nft": "NFTは生成後、指定のウォレットアドレスに送信されます。"
+      },
+      "returns": {
+        "title": "返品・交換について",
+        "digital_nature": "デジタルコンテンツの性質上、返品・交換は原則として承っておりません。",
+        "defect_policy": "サービスに不具合がある場合は、速やかにサポートまでご連絡ください。"
+      },
+      "cancellation": {
+        "title": "キャンセルについて",
+        "policy": "月額プランは次回更新日の24時間前までにキャンセル可能です。日割り返金は行っておりません。"
+      },
+      "requirements": {
+        "title": "動作環境",
+        "mobile": {
+          "title": "モバイルアプリ"
+        },
+        "ar": {
+          "title": "AR対応デバイス"
+        },
+        "browser": {
+          "title": "推奨ブラウザ"
+        }
+      },
+      "notes": {
+        "title": "その他の特記事項",
+        "blockchain_nature": "ブロックチェーン取引は不可逆的です",
+        "crypto_wallet": "NFT受取には暗号資産ウォレットが必要です",
+        "gas_responsibility": "ガス代の変動リスクはお客様負担となります",
+        "age_restriction": "13歳未満の方はご利用いただけません"
+      }
+    }
   }
 }


### PR DESCRIPTION
## 概要

フッターに必要な法的ページを作成しました。

## 変更内容

- プライバシーポリシーページ (/privacy) を作成
- 利用規約ページ (/terms) を作成
- 特定商取引法に基づく表記ページ (/legal) を作成
- 日本語・英語の翻訳を追加
- フッターのリンクを実際のページに更新

Closes #20

Generated with [Claude Code](https://claude.ai/code)