### PR TITLE
fix: ロードマップセクションを削除

### DIFF
--- a/landingpage/src/components/Footer.tsx
+++ b/landingpage/src/components/Footer.tsx
@@ -13,7 +13,6 @@ export default function Footer() {
       { label: t('footer.product_links.features'), href: '#features' },
       { label: t('footer.product_links.demo'), href: '#demo' },
       { label: t('footer.product_links.pricing'), href: '#pricing' },
-      { label: t('footer.product_links.roadmap'), href: '#roadmap' },
     ],
     legal: [
       { label: t('footer.legal_links.terms'), href: '/terms' },

--- a/landingpage/src/i18n/messages/en.json
+++ b/landingpage/src/i18n/messages/en.json
@@ -157,8 +157,7 @@
     "product_links": {
       "features": "Features",
       "demo": "Demo",
-      "pricing": "Pricing",
-      "roadmap": "Roadmap"
+      "pricing": "Pricing"
     },
     "company_links": {
       "team": "Team",

--- a/landingpage/src/i18n/messages/ja.json
+++ b/landingpage/src/i18n/messages/ja.json
@@ -152,8 +152,7 @@
     "product_links": {
       "features": "特徴",
       "demo": "デモ",
-      "pricing": "料金",
-      "roadmap": "ロードマップ"
+      "pricing": "料金"
     },
     "company_links": {
       "team": "チーム",


### PR DESCRIPTION
Issue #24 で指摘されたミスリーディングなロードマップの参照を削除しました。

- Footer.tsxからロードマップへのリンクを削除
- en.jsonから"Roadmap"の翻訳を削除
- ja.jsonから"ロードマップ"の翻訳を削除

Generated with [Claude Code](https://claude.ai/code)